### PR TITLE
Preinstall GHC and Yesod from Stackage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ Create your own `Dockerfile` inheriting from this image:
 FROM thoughtbot/heroku-haskell-stack
 ```
 
+Create a `stack-bootstrap` file containing large dependencies for your
+application. For example:
+
+```
+alex classy-prelude-yesod happy yesod-bin yesod
+```
+
+These dependencies will be installed in their own Docker layer, so changing your
+cabal file will not cause them to be reinstalled every time.
+
+Build your image:
+
+```
+docker build .
+```
+
 Here's a sample `bin/deploy` script you can use in your Heroku project, assuming
 you already have the heroku-docker Heroku plugin installed:
 


### PR DESCRIPTION
This will preinstall GHC and Yesod into the base image using Stack from
a specific LHS version. We can release a tag for each LHS version, so
you can do:

```
FROM thoughtbot/heroku-haskell-stack:lhs-5.5
```

This means that applications based on this image can select the
appropriate LHS version and download GHC and the ~180 Yesod dependencies
as an image instead of downloading and compiling them.
