### PR TITLE
Make README example POSIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ you already have the heroku-docker Heroku plugin installed:
 
 set -e
 
-if (( $# != 1 )); then
+if [ $# -ne 1 ]; then
   echo "Usage: ./bin/deploy (staging|production)"
   exit 1
 fi
 
-if [ $(uname) == "Darwin" ]; then
+if [ $(uname) = "Darwin" ]; then
   eval "$(docker-machine env default)"
 fi
 


### PR DESCRIPTION
`((` and `==` are bashisms and should not be used with `/bin/sh`.
