### PR TITLE
Update stack lts to 5.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 575159689BEFB442 \
   && rm -rf /var/lib/apt/lists/*
 
 # Preinstall GHC using Stack
-ENV STACK_LTS_VERSION 5.5
+ENV STACK_LTS_VERSION 5.11
 RUN stack setup --resolver lts-$STACK_LTS_VERSION
 
 # Install application framework in a separate layer for caching


### PR DESCRIPTION
FOMObot uses 5.11. Updating the dockerfile and pushing a new tag to dockerhub
