### PR TITLE
Add a file with the deployed Git commit hash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,12 @@ ENV PATH /root/.local/bin:$PATH
 RUN mkdir -p /app/user
 WORKDIR /app/user
 
+# Add a /app/GIT_HEAD_REF file with the git commit SHA that is currently
+# deployed
+COPY .git .git
+RUN cat ".git/$(cut -d' ' -f2 .git/HEAD)" > /app/GIT_HEAD_REF
+RUN rm -rf .git
+
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 575159689BEFB442 \
   && echo 'deb http://download.fpcomplete.com/ubuntu trusty main' > \
     /etc/apt/sources.list.d/fpco.list \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app/user
 
 # Add a /app/GIT_HEAD_REF file with the git commit SHA that is currently
 # deployed
-COPY .git .git
+COPY .git/HEAD .git/refs .git/
 RUN cat ".git/$(cut -d' ' -f2 .git/HEAD)" > /app/GIT_HEAD_REF
 RUN rm -rf .git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /app/user
 
 # Add a /app/GIT_HEAD_REF file with the git commit SHA that is currently
 # deployed
+RUN mkdir -p .git
 COPY .git/HEAD .git/refs .git/
 RUN cat ".git/$(cut -d' ' -f2 .git/HEAD)" > /app/GIT_HEAD_REF
 RUN rm -rf .git


### PR DESCRIPTION
Deploying with Docker means that there's no Git commit history on Heroku. To
keep track of which commit is live, add a file with the currently-deployed Git
commit hash.

I'm using this on Croniker: https://github.com/gabebw/croniker/blob/master/Dockerfile
